### PR TITLE
Adds check for `subView` element in `renderSubview`

### DIFF
--- a/src/components/SwipeRow.js
+++ b/src/components/SwipeRow.js
@@ -593,7 +593,7 @@ const SwipeRow = createReactClass({
         let activeSideStyle = this.getActiveSideStyle(isLeft);
         let panStyle = this.getSubViewPanStyle(isLeft);
         let wrapperStyle = this.getSubViewWrapperStyle(isLeft);
-        if (activeSide) {
+        if (activeSide && subView) {
             return (
                 <Animated.View style={[styles.subViewContainer, activeSideStyle, panStyle]} {...this.checkGetBlockCloseTimeout(isLeft)}>
                     <View style={[styles.subViewWrapper, wrapperStyle]} onLayout={onLayout}>


### PR DESCRIPTION
Amazing repo! Love the ease of use!

I did find a small crashing when using this repo.

1.) Each of my rows have a `status`
2.) Rows can swipe left, right or both depending on their status.

I encountered a sort of race condition in the following circumstance.

1.) Row has a hidden view
2.) Swipe out row to reveal hidden view
3.) Click hidden view (Action performed changes the status and that row no longer has a hidden view)
4.) React tries to clone a null `subView`

I solved this by checking to make sure we have a subView before we try to render it.

Would love to hear your thoughts!